### PR TITLE
Update value for use of example-robot-data

### DIFF
--- a/talos_rbprm/talos.py
+++ b/talos_rbprm/talos.py
@@ -39,7 +39,7 @@ class Robot(Parent):
     referenceConfig = [
         0.0,
         0.0,
-        1.02127,
+        1.0225,
         0.0,
         0.0,
         0.0,
@@ -81,7 +81,7 @@ class Robot(Parent):
     referenceConfig_elbowsUp = [
         0.0,
         0.0,
-        1.02127,
+        1.0225,
         0.0,
         0.0,
         0.0,
@@ -123,7 +123,7 @@ class Robot(Parent):
     referenceConfig_legsApart = [
         0.0,
         0.0,
-        1.02127,
+        1.0225,
         0.0,
         0.0,
         0.0,
@@ -165,7 +165,7 @@ class Robot(Parent):
     referenceConfig_armsFront = [
         0.0,
         0.0,
-        1.02127,
+        1.0225,
         0,
         0.0,
         0.0,
@@ -207,7 +207,7 @@ class Robot(Parent):
     referenceConfig_legsSide = [
         0,
         0,
-        0.9832773,
+        1.,
         0,
         0.0,
         0.0,

--- a/talos_rbprm/talos.py
+++ b/talos_rbprm/talos.py
@@ -336,13 +336,13 @@ class Robot(Parent):
     octreeSize = 0.01
     cType = "_6_DOF"
     rLegOffset = [0., 0., 0.0]
-    # rLegOffset[2] += 0.005
+    rLegOffset[2] -= 0.005
     rLegNormal = [0, 0, 1]
     rLegx = 0.1
     rLegy = 0.06
 
     lLegOffset = [0., 0., 0.0]
-    # lLegOffset[2] += 0.005
+    lLegOffset[2] -= 0.005
     lLegNormal = [0, 0, 1]
     lLegx = 0.1
     lLegy = 0.06

--- a/talos_rbprm/talos_abstract.py
+++ b/talos_rbprm/talos_abstract.py
@@ -25,12 +25,12 @@ class Robot(Parent):
     legX = 0.1
     legY = 0.06
 
-    ref_height = 1.02127
+    ref_height = 1.0225
     # reference position of the end effector position for each ROM
 
-    ref_EE_lLeg = [-0.008846952891378526, 0.0848172440888579, -1.019272022956703]
+    ref_EE_lLeg = [-0.008846952891378526, 0.0848172440888579, -1.0225]
     ref_EE_lLeg[0] = 0.  # assure symetry of dynamic constraints on flat ground
-    ref_EE_rLeg = [-0.008846952891378526, -0.0848172440888579, -1.019272022956703]
+    ref_EE_rLeg = [-0.008846952891378526, -0.0848172440888579, -1.0225]
     ref_EE_rLeg[0] = 0.
     ref_EE_lArm = [0.13028765672452458, 0.44360498616312666, -0.2881211563246389]
     ref_EE_rArm = [0.13028765672452458, -0.44360498616312666, -0.2881211563246389]


### PR DESCRIPTION
* Increase Root position along Z axis to avoid collision with the feet. 

* Increase offset along -Z axis for contact creation with the feet

This changes fix the unit tests when using example-robot-data package instead of talos_data. However, the fact that they are required show that both package contains different models of the robot. Most certainly the collision shape of the feet are different. 
This require further investigation. 